### PR TITLE
AP-9821 # Changed date based conditional logic to use start and end o…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@nylas/react": "^3.1.2",
-        "@oneblink/sdk-core": "^10.0.0-beta.2",
+        "@oneblink/sdk-core": "^10.0.0-beta.3",
         "@oneblink/storage": "^7.1.2-beta.2",
         "@react-google-maps/api": "^2.20.8",
         "@react-input/mask": "^2.0.4",
@@ -4602,9 +4602,9 @@
       }
     },
     "node_modules/@oneblink/sdk-core": {
-      "version": "10.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@oneblink/sdk-core/-/sdk-core-10.0.0-beta.2.tgz",
-      "integrity": "sha512-tA53LexnPKEtkvesSnLBc0VUUIPGf4o47KabUoYgiFmucJ1klbadaFcgXjQkKNL6EIlCgDneiyKsFTA/yQBIZg==",
+      "version": "10.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@oneblink/sdk-core/-/sdk-core-10.0.0-beta.3.tgz",
+      "integrity": "sha512-SrFLK/tIX2AhKHw6pLji97GydUeQ7RHAfG9bK5CUacnWC1hXZOiFUeVVknnjntDM5h1MiUhqi9pRiMXDJAAaig==",
       "license": "MIT",
       "engines": {
         "node": ">=24",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@nylas/react": "^3.1.2",
-    "@oneblink/sdk-core": "^10.0.0-beta.2",
+    "@oneblink/sdk-core": "^10.0.0-beta.3",
     "@oneblink/storage": "^7.1.2-beta.2",
     "@react-google-maps/api": "^2.20.8",
     "@react-input/mask": "^2.0.4",

--- a/src/apps/localisation-service.ts
+++ b/src/apps/localisation-service.ts
@@ -1,7 +1,12 @@
 import { submissionService } from '@oneblink/sdk-core'
 import tenants from './tenants'
 import parser from 'ua-parser-js'
-import { add, parse } from 'date-fns'
+import {
+  add,
+  endOfDay as dateFnsEndOfDay,
+  parse,
+  startOfDay as dateFnsStartOfDay,
+} from 'date-fns'
 
 let iosVersion: number | undefined
 const parsedUserAgent: parser.IResult = parser(window.navigator.userAgent)
@@ -310,10 +315,10 @@ function generateDateOffset({
 }
 
 /**
- * Parse a date/datetime string for conditional logic evaluation. Date-only
- * values (`YYYY-MM-DD`) are interpreted in the user's local timezone.
+ * Parse a day-only (`YYYY-MM-DD`) string for conditional logic evaluation in
+ * the user's local timezone. sdk-core only calls this for day-only values.
  */
-export function parseDate(value: string): Date {
+export function parseDayOnlyDate(value: string): Date {
   // Always return a Date so callers can use Number.isNaN(date.getTime()) to
   // detect unparseable values. generateDate returns undefined in that case.
   return (
@@ -329,6 +334,20 @@ export function parseDate(value: string): Date {
  */
 export function addDaysToDate(date: Date, days: number): Date {
   return add(date, { days })
+}
+
+/**
+ * Start of calendar day in the user's local timezone for conditional logic.
+ */
+export function startOfDay(date: Date): Date {
+  return dateFnsStartOfDay(date)
+}
+
+/**
+ * End of calendar day in the user's local timezone for conditional logic.
+ */
+export function endOfDay(date: Date): Date {
+  return dateFnsEndOfDay(date)
 }
 
 export const replaceSubmissionFormatters: submissionService.ReplaceInjectablesFormatters =

--- a/src/apps/payment-service.ts
+++ b/src/apps/payment-service.ts
@@ -15,7 +15,9 @@ import NSWGovPayPaymentProvider from './services/payment-providers/NSWGovPayPaym
 import WestpacQuickStreamPaymentProvider, * as westpacQuickStream from './services/payment-providers/WestpacQuickStreamPaymentProvider'
 import {
   addDaysToDate,
-  parseDate,
+  endOfDay,
+  parseDayOnlyDate,
+  startOfDay,
   replaceSubmissionFormatters,
 } from './localisation-service'
 import {
@@ -136,8 +138,10 @@ export function checkForPaymentSubmissionEvent(
     definition: formSubmission.definition,
     submission: formSubmission.submission,
     submissionTimestamp,
-    parseDate,
+    parseDayOnlyDate,
     addDaysToDate,
+    startOfDay,
+    endOfDay,
   })
   if (result) {
     console.log('Form has a payment submission event with amount', result)

--- a/src/apps/services/schedulingHandlers.ts
+++ b/src/apps/services/schedulingHandlers.ts
@@ -7,7 +7,12 @@ import {
   BaseNewFormSubmission,
 } from '../types/submissions'
 import { SchedulingUrlConfiguration } from '../types/scheduling'
-import { addDaysToDate, parseDate } from '../localisation-service'
+import {
+  addDaysToDate,
+  endOfDay,
+  parseDayOnlyDate,
+  startOfDay,
+} from '../localisation-service'
 
 const SCHEDULING_SUBMISSION_RESULT_KEY = 'SCHEDULING_SUBMISSION_RESULT'
 type SchedulingSubmissionResult = {
@@ -94,8 +99,10 @@ function checkForSchedulingSubmissionEvent(
     definition: baseFormSubmission.definition,
     submission: baseFormSubmission.submission,
     submissionTimestamp,
-    parseDate,
+    parseDayOnlyDate,
     addDaysToDate,
+    startOfDay,
+    endOfDay,
   })
   if (schedulingSubmissionEvent) {
     console.log(

--- a/tests/apps/localisation-service.test.ts
+++ b/tests/apps/localisation-service.test.ts
@@ -2,9 +2,9 @@ import tenants from '../../src/apps/tenants'
 import * as localisationService from '../../src/apps/localisation-service'
 import { describe, expect, test } from 'vitest'
 
-describe('parseDate / generateDate', () => {
+describe('parseDayOnlyDate / generateDate', () => {
   test('date-only values are parsed as local midnight', () => {
-    const date = localisationService.parseDate('2023-05-04')
+    const date = localisationService.parseDayOnlyDate('2023-05-04')
 
     expect(date.getFullYear()).toBe(2023)
     expect(date.getMonth()).toBe(4)
@@ -15,22 +15,20 @@ describe('parseDate / generateDate', () => {
     expect(date.getMilliseconds()).toBe(0)
   })
 
-  test('full ISO datetime strings preserve time (not date-only local midnight)', () => {
+  test('generateDate preserves full ISO datetime time (not date-only local midnight)', () => {
     // Afternoon UTC often lands on the next local calendar day in positive offsets
     // (e.g. AEST). Parsing as yyyy-MM-dd would lose the time and the correct day.
     const iso = '2023-05-04T14:30:00.000Z'
-    const parsed = localisationService.parseDate(iso)
     const generated = localisationService.generateDate({
       value: iso,
       daysOffset: undefined,
     })
-    const dateOnlyLocalMidnight = localisationService.parseDate('2023-05-04')
+    const dateOnlyLocalMidnight = localisationService.parseDayOnlyDate('2023-05-04')
 
-    expect(parsed.getTime()).toBe(new Date(iso).getTime())
     expect(generated?.getTime()).toBe(new Date(iso).getTime())
-    expect(parsed.getTime()).not.toBe(dateOnlyLocalMidnight.getTime())
-    expect(parsed.getUTCHours()).toBe(14)
-    expect(parsed.getUTCMinutes()).toBe(30)
+    expect(generated?.getTime()).not.toBe(dateOnlyLocalMidnight.getTime())
+    expect(generated?.getUTCHours()).toBe(14)
+    expect(generated?.getUTCMinutes()).toBe(30)
   })
 
   test('generateDate with daysOffset preserves ISO datetime time-of-day', () => {


### PR DESCRIPTION
…f day

## Requester Checklist

Please only check the items that you have actioned. Do not check items that are not applicable to your PR.

### Implementation

- [ ] Have you tested your implementation locally?
- [ ] If applicable, has an appropriate changelog entry been added? Do not include if you are fixing/changing something that is only in the current release.
- [ ] There are no warnings that have been suppressed unnecessarily
- [ ] Have automated tests been added, or have related ones been updated to cover the change?
- [ ] Have all OneBlink dependency updates been completed (eg apps / apps-react / types etc).
- [ ] Have you ensured this change does not add unwanted dependencies?
- [ ] If this PR contains a refactor, have relevant Jira testing tasks added?
- [ ] Changes that will knowingly make the feature/bug incomplete have been commented with TODO and a description of what needs to be done to finish the feature/bug
- [ ] Any changes made to public APIs have been reflected in the documentation
- [ ] Have you isolated business logic where possible to allow for unit testing?

### Logging and Debugging

- [ ] Are the error messages, if any, informative?
- [ ] Are there enough log events and are they written in a way that allows for easy debugging?
- [ ] "Debugging" code removed
- [ ] Front-end: No erroneous `Console.WriteLines`

### Readability

- [ ] All class, variable, property and method modifiers are provided with the smallest scope possible
- [ ] New files, variables and functions are descriptive/comprehensible and named consistently.
- [ ] There is no dead code (unreachable code)
- [ ] There is no usage of [magic numbers](<https://en.wikipedia.org/wiki/Magic_number_(programming)>)
- [ ] There is no commented out code.
- [ ] In hard-to-understand areas, comments exist and describe rationale or reasons for decisions in code

### Security

- [ ] All personal data inputs are checked (for the correct type, length/size, format, and range).
- [ ] No sensitive information is logged or visible in a stacktrace
- [ ] Are authorization and authentication handled correctly?
- [ ] Is (user) input validated, sanitized, and escaped to prevent security attacks such as cross-site scripting or SQL injection?
- [ ] Is data retrieved from external APIs or libraries checked for security issues?
- [ ] Do API endpoints return appropriate status codes

## Reviewer Guide

- It is important that you understand the purpose of the PR.
- You are encouraged to engage with the requestor if you do not understand any of the proposed code changes/additions/deletions.
- Do you, the reviewer, understand what the code does? Do you think a specific expert, like a security expert or a usability expert, should look over the code before it can be accepted?
- Is a framework, API, library, or service used that should not be used? Are there alternatives you could recommend?
- Are there existing hooks/components/functions in the same code base that could be utilised?
- When reviewing tests, attempt to identify missing edge cases that may be relevant to the proposed implementation
- Ensure you check for:
  - Security
  - Scalability
  - Performance
  - Maintainability

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when payment amounts and scheduling events fire based on date conditions, which can affect money and booking flows, though scope is limited to adapter wiring and a dependency bump.
> 
> **Overview**
> Upgrades **`@oneblink/sdk-core`** to `10.0.0-beta.3` and adapts the app’s date helpers so payment and scheduling submission-event checks match the SDK’s updated date conditional logic.
> 
> **`parseDate`** is renamed to **`parseDayOnlyDate`** (day-only `YYYY-MM-DD` in local time). New **`startOfDay`** and **`endOfDay`** wrappers are added and passed into `paymentService.checkForPaymentEvent` and `schedulingService.checkForSchedulingEvent` alongside the existing `addDaysToDate` hook. Tests are updated to target the renamed parser and to assert ISO datetimes via **`generateDate`** instead of the day-only parser.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9cf478230715712538908b23b40ff3fa041a662. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->